### PR TITLE
Feature GTFS Pathways test

### DIFF
--- a/src/__tests__/gtfs-pathways.test.ts
+++ b/src/__tests__/gtfs-pathways.test.ts
@@ -26,7 +26,7 @@ describe('GTFS Pathways service', () => {
     describe('Create Station', () => {
         describe('Auth', () => {
             it('When no auth token provided, Expect to return HTTP status 401', async () => {
-                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithoutAuthHeader);
+                const gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithoutAuthHeader);
                 const stationResponse = async () => {
                     await gtfsPathwaysApi.createStation(TdeiObjectFaker.getStation(seederData?.organizationId))
                 }
@@ -36,20 +36,18 @@ describe('GTFS Pathways service', () => {
 
         describe('Functional', () => {
             it('When creating new station, Expect to return newly created station id', async () => {
-                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
+                const gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
                 const stationResponse = await gtfsPathwaysApi.createStation(TdeiObjectFaker.getStation(seederData?.organizationId));
                 expect(stationResponse.status).toBe(200);
                 expect(stationResponse.data.data?.length).toBeGreaterThan(0);
             });
 
             it('When creating new station with same station_name, Expect to return HTTP Status 400', async () => {
-                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
-                let stationPayload = TdeiObjectFaker.getStation(seederData?.organizationId)
-                const firstStationResponse = await gtfsPathwaysApi.createStation(stationPayload);
-                expect(firstStationResponse.status).toBe(200);
-                expect(firstStationResponse.data.data?.length).toBeGreaterThan(0);
+                const gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
+                let payload = TdeiObjectFaker.getStation(seederData?.organizationId)
+                payload.station_name = <string>seederData?.stationName
                 const secondStationResponse = async () => {
-                    await gtfsPathwaysApi.createStation(stationPayload);
+                    await gtfsPathwaysApi.createStation(payload);
                 }
                 await expect(secondStationResponse()).rejects.toMatchObject({response: {status: 400}});
             });
@@ -57,21 +55,21 @@ describe('GTFS Pathways service', () => {
 
         describe('Validation', () => {
             it('When creating new station with empty station_name, Expect to return HTTP Status 400', async () => {
-                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
-                let stationPayload = TdeiObjectFaker.getStation(seederData?.organizationId)
-                stationPayload.station_name = ''
+                const gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
+                let payload = TdeiObjectFaker.getStation(seederData?.organizationId)
+                payload.station_name = ''
                 const stationResponse = async () => {
-                    await gtfsPathwaysApi.createStation(stationPayload);
+                    await gtfsPathwaysApi.createStation(payload);
                 }
                 await expect(stationResponse()).rejects.toMatchObject({response: {status: 400}});
             });
 
             it('When creating new station with empty tdei_org_id, Expect to return HTTP Status 400', async () => {
-                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
-                let stationPayload = TdeiObjectFaker.getStation(seederData?.organizationId)
-                stationPayload.tdei_org_id = ''
+                const gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
+                let payload = TdeiObjectFaker.getStation(seederData?.organizationId)
+                payload.tdei_org_id = ''
                 const stationResponse = async () => {
-                    await gtfsPathwaysApi.createStation(stationPayload);
+                    await gtfsPathwaysApi.createStation(payload);
                 }
                 await expect(stationResponse()).rejects.toMatchObject({response: {status: 400}});
             });
@@ -83,12 +81,9 @@ describe('GTFS Pathways service', () => {
     describe('Update Station', () => {
         describe('Auth', () => {
             it('When no auth token provided, Expect to return HTTP status 401', async () => {
-                let validGtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
-                const validStationResponse = await validGtfsPathwaysApi.createStation(TdeiObjectFaker.getStation(seederData?.organizationId));
-
-                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithoutAuthHeader);
+                const gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithoutAuthHeader);
                 const stationResponse = async () => {
-                    let payload = TdeiObjectFaker.getUpdateStation(validStationResponse?.data?.data)
+                    let payload = TdeiObjectFaker.getUpdateStation(<string>seederData?.stationId)
                     await gtfsPathwaysApi.updateStation(payload, <string>seederData?.organizationId)
                 }
                 await expect(stationResponse()).rejects.toMatchObject({response: {status: 401}});
@@ -97,9 +92,8 @@ describe('GTFS Pathways service', () => {
 
         describe('Functional', () => {
             it('When updating new station, Expect to return newly Updated station id', async () => {
-                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
-                const validStationResponse = await gtfsPathwaysApi.createStation(TdeiObjectFaker.getStation(seederData?.organizationId));
-                let payload = TdeiObjectFaker.getUpdateStation(validStationResponse?.data?.data)
+                const gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
+                let payload = TdeiObjectFaker.getUpdateStation(<string>seederData?.stationId)
                 const stationResponse = await gtfsPathwaysApi.updateStation(payload, <string>seederData?.organizationId);
                 expect(stationResponse.status).toBe(200);
             });
@@ -107,10 +101,9 @@ describe('GTFS Pathways service', () => {
 
         describe('Validation', () => {
             it('When updating new station with empty station_name, Expect to return HTTP Status 400', async () => {
-                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
-                const validStationResponse = await gtfsPathwaysApi.createStation(TdeiObjectFaker.getStation(seederData?.organizationId));
+                const gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
+                let payload = TdeiObjectFaker.getUpdateStation(<string>seederData?.stationId)
                 const stationResponse = async () => {
-                    let payload = TdeiObjectFaker.getUpdateStation(validStationResponse?.data?.data)
                     payload.station_name = ''
                     await gtfsPathwaysApi.updateStation(payload, <string>seederData?.organizationId);
                 }
@@ -118,20 +111,18 @@ describe('GTFS Pathways service', () => {
             });
 
             it('When updating new station with empty tdei_org_id, Expect to return HTTP Status 400', async () => {
-                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
-                const validStationResponse = await gtfsPathwaysApi.createStation(TdeiObjectFaker.getStation(seederData?.organizationId));
+                const gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
+                let payload = TdeiObjectFaker.getUpdateStation(<string>seederData?.stationId)
                 const stationResponse = async () => {
-                    let payload = TdeiObjectFaker.getUpdateStation(validStationResponse?.data?.data)
-                    payload.station_name = ''
                     await gtfsPathwaysApi.updateStation(payload, <string>'');
                 }
                 await expect(stationResponse()).rejects.toMatchObject({response: {status: 404}});
             });
 
             it('When updating new station with empty tdei_station_id, Expect to return HTTP Status 400', async () => {
-                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
+                const gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
+                let payload = TdeiObjectFaker.getUpdateStation('')
                 const stationResponse = async () => {
-                    let payload = TdeiObjectFaker.getUpdateStation('')
                     await gtfsPathwaysApi.updateStation(payload, <string>'');
                 }
                 await expect(stationResponse()).rejects.toMatchObject({response: {status: 404}});
@@ -144,7 +135,7 @@ describe('GTFS Pathways service', () => {
     describe('Get Station', () => {
         describe('Auth', () => {
             it('When no auth token provided, Expect to return HTTP status 401', async () => {
-                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithoutAuthHeader);
+                const gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithoutAuthHeader);
                 const stationResponse = async () => {
                     await gtfsPathwaysApi.getStation()
                 }
@@ -154,14 +145,14 @@ describe('GTFS Pathways service', () => {
 
         describe('Functional', () => {
             it('When searched without filters, Expect to return list of Stations of type Station', async () => {
-                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
+                const gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
                 const stationResponse = await gtfsPathwaysApi.getStation()
                 expect(stationResponse.status).toBe(200);
                 expect(stationResponse.data).toBeInstanceOf(Array);
             });
 
             it('When searched with tdei_org_id filter, Expect to return list of Stations matching filter', async () => {
-                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
+                const gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
                 const stationResponse = await gtfsPathwaysApi.getStation(undefined, undefined, seederData?.organizationId)
                 const data = stationResponse.data
                 expect(stationResponse.status).toBe(200);
@@ -171,23 +162,17 @@ describe('GTFS Pathways service', () => {
             });
 
             it('When searched with station name filter, Expect to return list of Stations matching filter', async () => {
-                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
-                let payload = TdeiObjectFaker.getStation(seederData?.organizationId)
-                const station_name = faker.name.firstName() + '_Station'
-                payload.station_name = station_name
-                await gtfsPathwaysApi.createStation(payload);
-                const stationResponse = await gtfsPathwaysApi.getStation(undefined, station_name)
+                const gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
+                const stationResponse = await gtfsPathwaysApi.getStation(undefined, <string>seederData?.stationName)
                 const data = stationResponse.data
                 expect(stationResponse.status).toBe(200);
                 expect(data).toBeInstanceOf(Array);
-                expect(data[0].station_name).toEqual(station_name);
+                expect(data[0].station_name).toEqual(seederData?.stationName);
             });
 
             it('When searched with tdei_station_id filter, Expect to return list of Stations matching filter', async () => {
-                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
-                const payload = TdeiObjectFaker.getStation(seederData?.organizationId)
-                const resp = await gtfsPathwaysApi.createStation(payload);
-                const tdei_station_id = resp.data.data
+                const gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
+                const tdei_station_id = <string>seederData?.stationId
                 const stationResponse = await gtfsPathwaysApi.getStation(tdei_station_id)
                 const data = stationResponse.data
                 expect(stationResponse.status).toBe(200);
@@ -195,9 +180,7 @@ describe('GTFS Pathways service', () => {
                 expect(data[0].tdei_station_id).toEqual(tdei_station_id);
             });
 
-            it('When searched with bbox name filter, Expect to return list of Stations matching filter', async () => {
-
-            });
+            it.todo('When searched with bbox name filter, Expect to return list of Stations matching filter');
         })
     })
 

--- a/src/__tests__/gtfs-pathways.test.ts
+++ b/src/__tests__/gtfs-pathways.test.ts
@@ -1,0 +1,212 @@
+import {Utility} from '../utils';
+import {
+    GTFSPathwaysStationApi,
+    AuthApi,
+} from 'tdei-management-client';
+import seed, {ISeedData} from '../data.seed';
+import {faker} from "@faker-js/faker";
+import {TdeiObjectFaker} from '../tdei-object-faker';
+
+describe('GTFS Pathways service', () => {
+    let configurationWithAuthHeader = Utility.getConfiguration();
+    let configurationWithoutAuthHeader = Utility.getConfiguration();
+    let seederData: ISeedData | undefined = undefined;
+    beforeAll(async () => {
+        seederData = await seed.generate();
+        let generalAPI = new AuthApi(configurationWithAuthHeader)
+        const loginResponse = await generalAPI.authenticate({
+            username: configurationWithAuthHeader.username,
+            password: configurationWithAuthHeader.password
+        })
+        configurationWithAuthHeader.baseOptions = {
+            headers: {...Utility.addAuthZHeader(loginResponse.data.access_token)}
+        };
+    }, 50000);
+
+    describe('Create Station', () => {
+        describe('Auth', () => {
+            it('When no auth token provided, Expect to return HTTP status 401', async () => {
+                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithoutAuthHeader);
+                const stationResponse = async () => {
+                    await gtfsPathwaysApi.createStation(TdeiObjectFaker.getStation(seederData?.organizationId))
+                }
+                await expect(stationResponse()).rejects.toMatchObject({response: {status: 401}});
+            });
+        });
+
+        describe('Functional', () => {
+            it('When creating new station, Expect to return newly created station id', async () => {
+                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
+                const stationResponse = await gtfsPathwaysApi.createStation(TdeiObjectFaker.getStation(seederData?.organizationId));
+                expect(stationResponse.status).toBe(200);
+                expect(stationResponse.data.data?.length).toBeGreaterThan(0);
+            });
+
+            it('When creating new station with same station_name, Expect to return HTTP Status 400', async () => {
+                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
+                let stationPayload = TdeiObjectFaker.getStation(seederData?.organizationId)
+                const firstStationResponse = await gtfsPathwaysApi.createStation(stationPayload);
+                expect(firstStationResponse.status).toBe(200);
+                expect(firstStationResponse.data.data?.length).toBeGreaterThan(0);
+                const secondStationResponse = async () => {
+                    await gtfsPathwaysApi.createStation(stationPayload);
+                }
+                await expect(secondStationResponse()).rejects.toMatchObject({response: {status: 400}});
+            });
+        });
+
+        describe('Validation', () => {
+            it('When creating new station with empty station_name, Expect to return HTTP Status 400', async () => {
+                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
+                let stationPayload = TdeiObjectFaker.getStation(seederData?.organizationId)
+                stationPayload.station_name = ''
+                const stationResponse = async () => {
+                    await gtfsPathwaysApi.createStation(stationPayload);
+                }
+                await expect(stationResponse()).rejects.toMatchObject({response: {status: 400}});
+            });
+
+            it('When creating new station with empty tdei_org_id, Expect to return HTTP Status 400', async () => {
+                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
+                let stationPayload = TdeiObjectFaker.getStation(seederData?.organizationId)
+                stationPayload.tdei_org_id = ''
+                const stationResponse = async () => {
+                    await gtfsPathwaysApi.createStation(stationPayload);
+                }
+                await expect(stationResponse()).rejects.toMatchObject({response: {status: 400}});
+            });
+
+            it.todo('When creating new station with invalid polygon, Expect to return HTTP Status 400');
+        });
+    });
+
+    describe('Update Station', () => {
+        describe('Auth', () => {
+            it('When no auth token provided, Expect to return HTTP status 401', async () => {
+                let validGtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
+                const validStationResponse = await validGtfsPathwaysApi.createStation(TdeiObjectFaker.getStation(seederData?.organizationId));
+
+                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithoutAuthHeader);
+                const stationResponse = async () => {
+                    let payload = TdeiObjectFaker.getUpdateStation(validStationResponse?.data?.data)
+                    await gtfsPathwaysApi.updateStation(payload, <string>seederData?.organizationId)
+                }
+                await expect(stationResponse()).rejects.toMatchObject({response: {status: 401}});
+            });
+        });
+
+        describe('Functional', () => {
+            it('When updating new station, Expect to return newly Updated station id', async () => {
+                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
+                const validStationResponse = await gtfsPathwaysApi.createStation(TdeiObjectFaker.getStation(seederData?.organizationId));
+                let payload = TdeiObjectFaker.getUpdateStation(validStationResponse?.data?.data)
+                const stationResponse = await gtfsPathwaysApi.updateStation(payload, <string>seederData?.organizationId);
+                expect(stationResponse.status).toBe(200);
+            });
+        });
+
+        describe('Validation', () => {
+            it('When updating new station with empty station_name, Expect to return HTTP Status 400', async () => {
+                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
+                const validStationResponse = await gtfsPathwaysApi.createStation(TdeiObjectFaker.getStation(seederData?.organizationId));
+                const stationResponse = async () => {
+                    let payload = TdeiObjectFaker.getUpdateStation(validStationResponse?.data?.data)
+                    payload.station_name = ''
+                    await gtfsPathwaysApi.updateStation(payload, <string>seederData?.organizationId);
+                }
+                await expect(stationResponse()).rejects.toMatchObject({response: {status: 400}});
+            });
+
+            it('When updating new station with empty tdei_org_id, Expect to return HTTP Status 400', async () => {
+                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
+                const validStationResponse = await gtfsPathwaysApi.createStation(TdeiObjectFaker.getStation(seederData?.organizationId));
+                const stationResponse = async () => {
+                    let payload = TdeiObjectFaker.getUpdateStation(validStationResponse?.data?.data)
+                    payload.station_name = ''
+                    await gtfsPathwaysApi.updateStation(payload, <string>'');
+                }
+                await expect(stationResponse()).rejects.toMatchObject({response: {status: 404}});
+            });
+
+            it('When updating new station with empty tdei_station_id, Expect to return HTTP Status 400', async () => {
+                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
+                const stationResponse = async () => {
+                    let payload = TdeiObjectFaker.getUpdateStation('')
+                    await gtfsPathwaysApi.updateStation(payload, <string>'');
+                }
+                await expect(stationResponse()).rejects.toMatchObject({response: {status: 404}});
+            });
+
+            it.todo('When updating new station with invalid polygon, Expect to return HTTP Status 400');
+        });
+    });
+
+    describe('Get Station', () => {
+        describe('Auth', () => {
+            it('When no auth token provided, Expect to return HTTP status 401', async () => {
+                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithoutAuthHeader);
+                const stationResponse = async () => {
+                    await gtfsPathwaysApi.getStation()
+                }
+                await expect(stationResponse()).rejects.toMatchObject({response: {status: 401}});
+            });
+        })
+
+        describe('Functional', () => {
+            it('When searched without filters, Expect to return list of Stations of type Station', async () => {
+                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
+                const stationResponse = await gtfsPathwaysApi.getStation()
+                expect(stationResponse.status).toBe(200);
+                expect(stationResponse.data).toBeInstanceOf(Array);
+            });
+
+            it('When searched with tdei_org_id filter, Expect to return list of Stations matching filter', async () => {
+                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
+                const stationResponse = await gtfsPathwaysApi.getStation(undefined, undefined, seederData?.organizationId)
+                const data = stationResponse.data
+                expect(stationResponse.status).toBe(200);
+                expect(Array.isArray(data)).toBe(true);
+                expect(data).toBeInstanceOf(Array);
+                expect(data[0].tdei_org_id).toEqual(seederData?.organizationId);
+            });
+
+            it('When searched with station name filter, Expect to return list of Stations matching filter', async () => {
+                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
+                let payload = TdeiObjectFaker.getStation(seederData?.organizationId)
+                const station_name = faker.name.firstName() + '_Station'
+                payload.station_name = station_name
+                await gtfsPathwaysApi.createStation(payload);
+                const stationResponse = await gtfsPathwaysApi.getStation(undefined, station_name)
+                const data = stationResponse.data
+                expect(stationResponse.status).toBe(200);
+                expect(data).toBeInstanceOf(Array);
+                expect(data[0].station_name).toEqual(station_name);
+            });
+
+            it('When searched with tdei_station_id filter, Expect to return list of Stations matching filter', async () => {
+                let gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
+                const payload = TdeiObjectFaker.getStation(seederData?.organizationId)
+                const resp = await gtfsPathwaysApi.createStation(payload);
+                const tdei_station_id = resp.data.data
+                const stationResponse = await gtfsPathwaysApi.getStation(tdei_station_id)
+                const data = stationResponse.data
+                expect(stationResponse.status).toBe(200);
+                expect(data).toBeInstanceOf(Array);
+                expect(data[0].tdei_station_id).toEqual(tdei_station_id);
+            });
+
+            it('When searched with bbox name filter, Expect to return list of Stations matching filter', async () => {
+
+            });
+        })
+    })
+
+    describe('Delete Station', () => {
+        describe('Auth', () => {
+            it.todo('When no auth token provided, Expect to return HTTP status 401')
+
+            it.todo('When deleting station id, Expect to return success')
+        })
+    })
+});
+

--- a/src/__tests__/gtfs-pathways.test.ts
+++ b/src/__tests__/gtfs-pathways.test.ts
@@ -4,7 +4,6 @@ import {
     AuthApi,
 } from 'tdei-management-client';
 import seed, {ISeedData} from '../data.seed';
-import {faker} from "@faker-js/faker";
 import {TdeiObjectFaker} from '../tdei-object-faker';
 
 describe('GTFS Pathways service', () => {
@@ -46,10 +45,10 @@ describe('GTFS Pathways service', () => {
                 const gtfsPathwaysApi = new GTFSPathwaysStationApi(configurationWithAuthHeader);
                 let payload = TdeiObjectFaker.getStation(seederData?.organizationId)
                 payload.station_name = <string>seederData?.stationName
-                const secondStationResponse = async () => {
+                const stationResponse = async () => {
                     await gtfsPathwaysApi.createStation(payload);
                 }
-                await expect(secondStationResponse()).rejects.toMatchObject({response: {status: 400}});
+                await expect(stationResponse()).rejects.toMatchObject({response: {status: 400}});
             });
         });
 

--- a/src/data.seed.ts
+++ b/src/data.seed.ts
@@ -1,14 +1,34 @@
-import { existsSync } from "fs";
-import { readFile, writeFile } from "fs/promises";
-import { AuthApi, GTFSFlexServiceApi, GTFSPathwaysStationApi, OrganizationApi, RegisterResponse, User, UserManagementApi } from "tdei-management-client";
-import { TdeiObjectFaker } from "./tdei-object-faker";
-import { Utility } from "./utils";
+import {existsSync} from "fs";
+import {readFile, writeFile} from "fs/promises";
+import {
+    AuthApi,
+    GTFSFlexServiceApi,
+    GTFSPathwaysStationApi,
+    OrganizationApi,
+    RegisterResponse,
+    User,
+    UserManagementApi
+} from "tdei-management-client";
+import {TdeiObjectFaker} from "./tdei-object-faker";
+import {Utility} from "./utils";
+
+export interface ServiceInterface {
+    id: string,
+    name: string
+}
+
+export interface StationInterface {
+    id: string,
+    name: string
+}
 
 export interface ISeedData {
     organizationId: string,
     user: User,
     stationId: string,
+    stationName: string,
     serviceId: string
+    serviceName: string
 }
 
 class SeedData {
@@ -19,7 +39,9 @@ class SeedData {
         organizationId: "",
         user: {},
         stationId: "",
-        serviceId: ""
+        stationName: "",
+        serviceId: "",
+        serviceName: ""
     };
 
     constructor() {
@@ -32,32 +54,35 @@ class SeedData {
             password: this.configurationWithAuthHeader.password
         });
         this.configurationWithAuthHeader.baseOptions = {
-            headers: { ...Utility.addAuthZHeader(loginResponse.data.access_token) }
+            headers: {...Utility.addAuthZHeader(loginResponse.data.access_token)}
         };
     }
 
     /**
-     * 
+     *
      * @param freshSeed if true, it will always generate new seed data otherwise read from local generated seed.data.json
-     * @returns 
+     * @returns
      */
     public async generate(freshSeed: boolean = false) {
         await this.setAuthentication();
 
         //Read from existing seed data if available else generate new seed data.
         if (!freshSeed && existsSync('seed.data.json')) {
-            const data = await readFile('seed.data.json', { encoding: 'utf8' });
+            const data = await readFile('seed.data.json', {encoding: 'utf8'});
             if (data) {
                 console.log("Serving from local seed data!");
                 this.data = JSON.parse(data);
             }
-        }
-        else {
+        } else {
             try {
                 console.log("Generating seed data");
                 this.data.organizationId = await this.createOrganization();
-                this.data.serviceId = await this.createService(this.data.organizationId);
-                this.data.stationId = await this.createStation(this.data.organizationId);
+                const service = await this.createService(this.data.organizationId);
+                this.data.serviceId = service?.id
+                this.data.serviceName = service?.name
+                const station = await this.createStation(this.data.organizationId);
+                this.data.stationId = station?.id
+                this.data.stationName = station?.name
                 this.data.user = await this.createUser();
 
                 this.writeFile();
@@ -70,8 +95,12 @@ class SeedData {
 
     private writeFile() {
         writeFile('./seed.data.json', JSON.stringify(this.data), 'utf8')
-            .then(() => { console.log('Seed file created successfully !'); })
-            .catch(err => { console.error("Error generating seed file.  " + err); });
+            .then(() => {
+                console.log('Seed file created successfully !');
+            })
+            .catch(err => {
+                console.error("Error generating seed file.  " + err);
+            });
     }
 
     private async createOrganization(): Promise<string> {
@@ -88,18 +117,26 @@ class SeedData {
         return response.data.data!;
     }
 
-    private async createStation(orgId: string): Promise<string> {
+    private async createStation(orgId: string): Promise<StationInterface> {
         console.log("Creating station");
-        let userManagementApi = new GTFSFlexServiceApi(this.configurationWithAuthHeader);
-        const response = await userManagementApi.createService(TdeiObjectFaker.getService(orgId));
-        return response.data.data!;
+        let stationApi = new GTFSPathwaysStationApi(this.configurationWithAuthHeader);
+        const payload = TdeiObjectFaker.getStation(orgId)
+        const response = await stationApi.createStation(payload);
+        return {
+            id: response.data.data!,
+            name: payload.station_name
+        }
     }
 
-    private async createService(orgId: string): Promise<string> {
+    private async createService(orgId: string): Promise<ServiceInterface> {
         console.log("Creating service");
-        let stationApi = new GTFSPathwaysStationApi(this.configurationWithAuthHeader);
-        const response = await stationApi.createStation(TdeiObjectFaker.getStation(orgId));
-        return response.data.data!;
+        let userManagementApi = new GTFSFlexServiceApi(this.configurationWithAuthHeader);
+        const payload = TdeiObjectFaker.getService(orgId)
+        const response = await userManagementApi.createService(payload);
+        return {
+            id: response.data.data!,
+            name: payload.service_name
+        };
     }
 }
 

--- a/src/data.seed.ts
+++ b/src/data.seed.ts
@@ -71,11 +71,11 @@ class SeedData {
                 console.log("Generating seed data");
                 this.data.organizationId = await this.createOrganization();
                 const service = await this.createService(this.data.organizationId);
-                this.data.serviceId = service?.id
-                this.data.serviceName = service?.name
+                this.data.serviceId = <string>service?.id
+                this.data.serviceName = <string>service?.name
                 const station = await this.createStation(this.data.organizationId);
-                this.data.stationId = station?.id
-                this.data.stationName = station?.name
+                this.data.stationId = <string>station?.id
+                this.data.stationName = <string>station?.name
                 this.data.user = await this.createUser();
                 await this.assignOrgRoleToUser(this.data.user.email!, this.data.organizationId);
 

--- a/src/tdei-object-faker.ts
+++ b/src/tdei-object-faker.ts
@@ -63,6 +63,23 @@ export class TdeiObjectFaker {
         };
     }
 
+    static getFakePolygon(): Polygon {
+        return {
+            type: PolygonTypeEnum.FeatureCollection,
+            features: [
+                {
+                    type: GeoJSONFeatureTypeEnum.Feature,
+                    properties: {},
+                    geometry: {
+                        // type: "Polygon",
+                        type: GeoJSONPolygonTypeEnum.Polygon,
+                        coordinates: []
+                    }
+                }
+            ]
+        };
+    }
+
     private static getCoordinates(): number[][] {
         var randomCoordinates: number[][] = [];
         var firstRandom = [

--- a/src/tdei-object-faker.ts
+++ b/src/tdei-object-faker.ts
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker";
-import { GeoJSONFeatureTypeEnum, GeoJSONPolygonTypeEnum, Organization, Polygon, PolygonTypeEnum, Register, Service, Station } from "tdei-management-client";
+import { GeoJSONFeatureTypeEnum, GeoJSONPolygonTypeEnum, Organization, Polygon, PolygonTypeEnum, Register, Service, Station, StationUpdate } from "tdei-management-client";
 
 export class TdeiObjectFaker {
     static getService(orgId: string): Service {
@@ -9,13 +9,23 @@ export class TdeiObjectFaker {
             polygon: this.getPolygon()
         };
     }
-    static getStation(orgId: string): Station {
+    static getStation(orgId: string | undefined): Station {
         return <Station>{
             station_name: faker.name.firstName() + "_Station",
             tdei_org_id: orgId,
             polygon: this.getPolygon()
         };
     }
+
+    static getUpdateStation(stationId: string | undefined): StationUpdate {
+        return <StationUpdate>{
+            station_name: faker.name.firstName() + "_Station",
+            tdei_station_id: stationId,
+            polygon: this.getPolygon()
+        };
+    }
+
+
     static getUser(): Register {
         return <Register>{
             email: faker.internet.email(),


### PR DESCRIPTION
**There are 5 unit test cases which are pending, need more clarification**

|Service Category| API Under Test | Sub Area Under Test | Scenario | Expectation | Status |
|--|--|--|--|--|--|
| GTFS Pathways | Create Station | Auth |When no auth token provided | Expect to return HTTP status 401 |:white_check_mark:|
| GTFS Pathways | Create Station | Functional | When creating new station | Expect to return newly created station id |:white_check_mark:|
| GTFS Pathways | Create Station | Functional | When creating new station with same station_name | Expect to return HTTP Status 400 | :white_check_mark:|
| GTFS Pathways | Create Station | Validation | When creating new station with empty station_name | Expect to return HTTP Status 400 |:white_check_mark:|
| GTFS Pathways | Create Station | Validation | When creating new station with empty tdei_org_id | Expect to return HTTP Status 400 |:white_check_mark:|
| GTFS Pathways | Create Station | Validation | When creating new station with invalid polygon | Expect to return HTTP Status 400 |❌|
|--|--|--|--|--|--|
| GTFS Pathways | Update Station | Auth |When no auth token provided | Expect to return HTTP status 401 |:white_check_mark:|
| GTFS Pathways | Update Station | Functional | When updating new station | Expect to return newly Updated station id |:white_check_mark:|
| GTFS Pathways | Update Station | Validation | When updating new station with empty station_name | Expect to return HTTP Status 400 |:white_check_mark:|
| GTFS Pathways | Update Station | Validation | When updating new station with empty tdei_org_id | Expect to return HTTP Status 400 |:white_check_mark:|
| GTFS Pathways | Update Station | Validation | When updating new station with empty tdei_station_id | Expect to return HTTP Status 400 |:white_check_mark:|
| GTFS Pathways | Update Station | Validation | When updating new station with invalid polygon | Expect to return HTTP Status 400 |❌|
|--|--|--|--|--|--|
| GTFS Pathways | Get Stations | Auth |When no auth token provided | Expect to return HTTP status 401 |:white_check_mark:|
| GTFS Pathways | Get Stations | Functional | When searched without filters | Expect to return list of Stations of type Station |:white_check_mark:|
| GTFS Pathways | Get Stations | Functional | When searched with tdei_org_id filter | Expect to return list of Stations matching filter |:white_check_mark:|
| GTFS Pathways | Get Stations | Functional | When searched with station name filter | Expect to return list of Stations matching fiter |:white_check_mark:|
| GTFS Pathways | Get Stations | Functional | When searched with tdei_station_id filter | Expect to return list of Stations matching fiter |:white_check_mark:|
| GTFS Pathways | Get Stations | Functional | When searched with bbox name filter | Expect to return list of Stations matching fiter |❌|
|--|--|--|--|--|--|
| GTFS Pathways | Delete Station | Auth |When no auth token provided | Expect to return HTTP status 401 |❌|
| GTFS Pathways | Delete Station | Auth |When deleting station id | Expect to return success |❌|
|--|--|--|--|--|--|
