### PR TITLE
Refactor polygon assertion to handle null cases

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,6 +5,7 @@ export default async (): Promise<Config> => {
         verbose: true,
         preset: 'ts-jest',
         testEnvironment: 'node',
+        testTimeout: 15000,
         globalSetup: "./global-setup.ts",
         reporters: [
             "default",

--- a/src/__tests__/gtfs-flex.roles.test.ts
+++ b/src/__tests__/gtfs-flex.roles.test.ts
@@ -69,11 +69,12 @@ describe('GTFS Flex service', () => {
                 expect(serviceResponse.status).toBe(200);
                expect(serviceResponse.data).toBeInstanceOf(Array);
                 serviceResponse.data.forEach(service => {
+                    expectPolygon(service.polygon);
                     expect(service).toMatchObject(<Service>{
                         tdei_org_id: expect.any(String),
                         tdei_service_id: expect.any(String),
                         service_name: expect.any(String),
-                        polygon: expect.anything() as null | Polygon
+                        polygon: expect.any(Object || null)
                     })
                 })
             });
@@ -81,3 +82,11 @@ describe('GTFS Flex service', () => {
     })
 });
 
+function expectPolygon(polygon: any) {
+  if (polygon) {
+      let aPolygon = polygon as Polygon;
+      expect(typeof aPolygon.features).not.toBeNull();
+      expect(aPolygon.features?.length).toBeGreaterThan(0);
+
+  }
+}

--- a/src/__tests__/gtfs-flex.test.ts
+++ b/src/__tests__/gtfs-flex.test.ts
@@ -189,11 +189,12 @@ describe('GTFS Flex service', () => {
                 expect(serviceResponse.status).toBe(200);
                 expect(serviceResponse.data).toBeInstanceOf(Array);
                 serviceResponse.data.forEach(service => {
+                   expectPolygon(service.polygon);
                     expect(service).toMatchObject(<Service>{
                         tdei_org_id: expect.any(String),
                         tdei_service_id: expect.any(String),
                         service_name: expect.any(String),
-                        polygon: expect.anything() as null | Polygon
+                        polygon: expect.any(Object || null)
                     })
                 })
             });
@@ -209,11 +210,12 @@ describe('GTFS Flex service', () => {
                 expect(data).toBeInstanceOf(Array);
             
                 serviceResponse.data.forEach(service => {
+                    expectPolygon(service.polygon);
                     expect(service).toMatchObject(<Service>{
                         tdei_org_id: seederData?.organization?.tdei_org_id,
                         tdei_service_id: expect.any(String),
                         service_name: expect.any(String),
-                        polygon: expect.anything() as null | Polygon
+                        polygon: expect.any(Object || null)
                     })
                 })
             });
@@ -228,11 +230,12 @@ describe('GTFS Flex service', () => {
                 expect(serviceResponse.status).toBe(200);
                 expect(data).toBeInstanceOf(Array);
                 serviceResponse.data.forEach(service => {
+                    expectPolygon(service.polygon);
                     expect(service).toMatchObject(<Service>{
                         tdei_org_id: expect.any(String),
                         tdei_service_id: expect.any(String),
                         service_name: seederData?.service?.service_name,
-                        polygon: expect.anything() as null | Polygon
+                        polygon: expect.any(Object || null)
                     })
                 })
             });
@@ -248,11 +251,12 @@ describe('GTFS Flex service', () => {
                 expect(serviceResponse.status).toBe(200);
                 expect(data).toBeInstanceOf(Array);
                 serviceResponse.data.forEach(service => {
+                    expectPolygon(service.polygon);
                     expect(service).toMatchObject(<Service>{
                         tdei_org_id: expect.any(String),
                         tdei_service_id: seederData?.service?.tdei_service_id,
                         service_name: expect.any(String),
-                        polygon: expect.anything() as null | Polygon
+                        polygon: expect.any(Object || null)
                     })
                 })
             });
@@ -294,3 +298,11 @@ describe('GTFS Flex service', () => {
     })
 });
 
+function expectPolygon(polygon: any) {
+    if (polygon) {
+        let aPolygon = polygon as Polygon;
+        expect(typeof aPolygon.features).not.toBeNull();
+        expect(aPolygon.features?.length).toBeGreaterThan(0);
+  
+    }
+  }

--- a/src/__tests__/gtfs-pathways.roles.test.ts
+++ b/src/__tests__/gtfs-pathways.roles.test.ts
@@ -65,11 +65,12 @@ describe('GTFS Pathways Service Role Testing - Data Generator User', () => {
                 expect(stationResponse.status).toBe(200);
                 expect(stationResponse.data).toBeInstanceOf(Array);
                 stationResponse.data.forEach(station => {
+                    expectPolygon(station.polygon);
                     expect(station).toMatchObject(<Station>{
                         tdei_station_id: expect.any(String),
                         tdei_org_id: expect.any(String),
                         station_name: expect.any(String),
-                        polygon: expect.anything() as null | Polygon
+                        polygon: expect.any(Object || null)
 
                     })
                 })
@@ -78,3 +79,11 @@ describe('GTFS Pathways Service Role Testing - Data Generator User', () => {
     });
 });
 
+function expectPolygon(polygon: any) {
+    if (polygon) {
+        let aPolygon = polygon as Polygon;
+        expect(typeof aPolygon.features).not.toBeNull();
+        expect(aPolygon.features?.length).toBeGreaterThan(0);
+  
+    }
+  }

--- a/src/__tests__/gtfs-pathways.test.ts
+++ b/src/__tests__/gtfs-pathways.test.ts
@@ -175,11 +175,12 @@ describe('GTFS Pathways service', () => {
                 expect(stationResponse.status).toBe(200);
                 expect(stationResponse.data).toBeInstanceOf(Array);
                 stationResponse.data.forEach(station => {
+                    expectPolygon(station.polygon);
                     expect(station).toMatchObject(<Station>{
                         tdei_station_id: expect.any(String),
                         tdei_org_id: expect.any(String),
                         station_name: expect.any(String),
-                        polygon: expect.anything() as null | Polygon
+                        polygon: expect.any(Object || null)
                     })
                 })
             });
@@ -195,11 +196,12 @@ describe('GTFS Pathways service', () => {
                 expect(Array.isArray(data)).toBe(true);
                 expect(data).toBeInstanceOf(Array);
                 stationResponse.data.forEach(station => {
+                    expectPolygon(station.polygon);
                     expect(station).toMatchObject(<Station>{
                         tdei_station_id: expect.any(String),
                         tdei_org_id: seederData?.organization?.tdei_org_id,
                         station_name: expect.any(String),
-                        polygon: expect.anything() as null | Polygon
+                        polygon: expect.any(Object || null)
                     })
                 })
             });
@@ -213,11 +215,12 @@ describe('GTFS Pathways service', () => {
                 expect(stationResponse.status).toBe(200);
                 expect(data).toBeInstanceOf(Array);
                 stationResponse.data.forEach(station => {
+                    expectPolygon(station.polygon);
                     expect(station).toMatchObject(<Station>{
                         tdei_station_id: expect.any(String),
                         tdei_org_id: expect.any(String),
                         station_name: seederData?.station?.station_name,
-                        polygon: expect.anything() as null | Polygon
+                        polygon: expect.any(Object || null)
                     })
                 })
             });
@@ -232,11 +235,12 @@ describe('GTFS Pathways service', () => {
                 expect(stationResponse.status).toBe(200);
                 expect(data).toBeInstanceOf(Array);
                 stationResponse.data.forEach(station => {
+                    expectPolygon(station.polygon);
                     expect(station).toMatchObject(<Station>{
                         tdei_station_id: seederData?.station?.tdei_station_id,
                         tdei_org_id: expect.any(String),
                         station_name: expect.any(String),
-                        polygon: expect.anything() as null | Polygon
+                        polygon: expect.any(Object || null)
                     })
                 })
             });
@@ -274,3 +278,11 @@ describe('GTFS Pathways service', () => {
     })
 });
 
+function expectPolygon(polygon: any) {
+    if (polygon) {
+        let aPolygon = polygon as Polygon;
+        expect(typeof aPolygon.features).not.toBeNull();
+        expect(aPolygon.features?.length).toBeGreaterThan(0);
+  
+    }
+  }

--- a/src/__tests__/organization.test.ts
+++ b/src/__tests__/organization.test.ts
@@ -219,14 +219,14 @@ describe("Organization service", () => {
         expect(oraganizationResponse.status).toBe(200);
         expect(oraganizationResponse.data).toBeInstanceOf(Array);
         oraganizationResponse.data.forEach(org => {
+          expectPolygon(org.polygon);
           expect(org).toMatchObject(<OrganizationList>{
-
             tdei_org_id: expect.any(String),
             name: expect.any(String),
             phone: expect.any(String),
             url: expect.any(String),
             address: expect.any(String),
-            polygon: expect.anything() as null | Polygon,
+            polygon: expect.any(Object || null),
             poc: expect.anything() as POC[]
           })
         })
@@ -245,14 +245,14 @@ describe("Organization service", () => {
         expect(oraganizationResponse.status).toBe(200);
         expect(Array.isArray(data)).toBe(true);
         oraganizationResponse.data.forEach(org => {
+          expectPolygon(org.polygon);
           expect(org).toMatchObject(<OrganizationList>{
-
             tdei_org_id: seederData?.organization?.tdei_org_id,
             name: expect.any(String),
             phone: expect.any(String),
             url: expect.any(String),
             address: expect.any(String),
-            polygon: expect.anything() as null | Polygon,
+            polygon: expect.any(Object || null),
             poc: expect.anything() as POC[]
           })
         })
@@ -271,14 +271,14 @@ describe("Organization service", () => {
         expect(oraganizationResponse.status).toBe(200);
         expect(Array.isArray(data)).toBe(true);
         oraganizationResponse.data.forEach(org => {
+          expectPolygon(org.polygon);
           expect(org).toMatchObject(<OrganizationList>{
-
             tdei_org_id: seederData?.organization?.tdei_org_id,
             name: seederData?.organization?.org_name,
             phone: expect.any(String),
             url: expect.any(String),
             address: expect.any(String),
-            polygon: expect.anything() as null | Polygon,
+            polygon: expect.any(Object || null),
             poc: expect.anything() as POC[]
           })
         })
@@ -328,7 +328,14 @@ describe("Organization service", () => {
   });
 });
 
+function expectPolygon(polygon: any) {
+  if (polygon) {
+      let aPolygon = polygon as Polygon;
+      expect(typeof aPolygon.features).not.toBeNull();
+      expect(aPolygon.features?.length).toBeGreaterThan(0);
 
+  }
+}
 
 
 


### PR DESCRIPTION
Known issue: 

For OrganizationApi response returned is OrganizationList. And one of the parameter is org_name whereas in interface it is defined as "name". 